### PR TITLE
add missing static function declaration

### DIFF
--- a/page.php
+++ b/page.php
@@ -22,7 +22,7 @@ class MixPanel {
    * Inserts the value for the mixpanel.track() API Call
    * @return boolean technically this should be html.. 
    */
-  function insert_event()
+  static function insert_event()
   {
     $event_label = self::get_post_event_label(); 
     $settings = (array) get_option( 'mixpanel_settings' );
@@ -61,7 +61,7 @@ class MixPanel {
    *
    * @return [type] [description]
    */
-  function insert_tracker()
+  static function insert_tracker()
   {
     $settings = (array) get_option( 'mixpanel_settings' );
     if(!isset($settings['token_id'])) {


### PR DESCRIPTION
Refactor to Strict standards
Otherwise you could get this message with newer php versions:
( ! ) Strict standards: call_user_func_array() expects parameter 1 to be a valid callback, non-static method MixPanel::insert_event() should not be called statically in ... 
